### PR TITLE
Add explicit SHELL path

### DIFF
--- a/unwired-modules/Makefile
+++ b/unwired-modules/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, ${USEMODULE})))
 INCLUDES += $(addprefix -I../../unwired-modules/, $(wildcard $(addsuffix /include, $(filter umdk-%, ${USEMODULE}))))
 CFLAGS += $(addprefix -D, $(subst umdk-, umdk_, $(filter umdk-%, ${USEMODULE})))


### PR DESCRIPTION
If /bin/bash is not defined explicitly, make uses /bin/sh. Which, for example, is a symlink to /bin/dash (and not /bin/bash) in Ubuntu, so it causes errors during build.