### PR TITLE
drivers/adxl345: Fix byte swap on reading function

### DIFF
--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -23,6 +23,7 @@
 
 #include "assert.h"
 #include "periph/i2c.h"
+#include "byteorder.h"
 #include "adxl345.h"
 #include "adxl345_regs.h"
 #include "adxl345_params.h"
@@ -83,9 +84,11 @@ void adxl345_read(const adxl345_t *dev, adxl345_data_t *data)
     i2c_read_regs(ADXL345_BUS, ADXL345_ADDR, ADXL345_DATA_X0, (void *)result, 6, 0);
     i2c_release(ADXL345_BUS);
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    /* ADXL345 returns value in little endian, so swap is needed on big endian
+     * platforms. See Analog Devices ADXL345 datasheet page 27. */
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     for (int i = 0; i < 3; i++) {
-        result[i] = ((result[i] & 0xFF) << 8 | (result[i] >> 8));
+        result[i] = byteorder_swaps((uint16_t)result[i]);
     }
 #endif
 


### PR DESCRIPTION
### Contribution description
I tested this PR on nucleo-f410rb, samr21-xpro and arduino-mega-2560 boards. 
Both full-res and non-full-res modes work, even with different scales (scale factors are being correctly applied). Also the ROM size is now reduced by ~3Kb (compared to the current master).

However while testing with the `tests/driver_adxl345` application I could not get correct acceleration values.

While going through the code I realized that after reading the values from the DATAx0 and DATAx1 registers for every axis, the bytes were being swapped on little endian platforms. According to the [device datasheet](http://www.analog.com/media/en/technical-documentation/data-sheets/ADXL345.pdf) (p 27): __"The output data is twos complement, with DATAx0 as the least significant byte and DATAx1 as the most significant byte."__, there is no need for this. Swapping is only necessary on BE. Also this should be done using the functions provided in `byteorder`.

### Testing
1. Connect sensor to the I2C bus of your board
2. Run
```shell
make clean flash term -C tests/driver_adxl345
```
3. With the sensor on the table you should get 1000 mg on the Z axis.
4. Move the sensor around and values should change accordingly.