### PR TITLE
boards/nucleo-l152re: fix i2c configuration

### DIFF
--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -221,12 +221,32 @@ static const spi_conf_t spi_config[] = {
 #define I2C_1_ERR_ISR       isr_i2c2_er
 
 static const i2c_conf_t i2c_config[] = {
-    /* device, port, scl-, sda-pin-number, I2C-AF, ER-IRQn, EV-IRQn */
-    {I2C1, GPIO_PIN(PORT_B,  8), GPIO_PIN(PORT_B,  9), GPIO_OD_PU,
-     GPIO_AF4, I2C1_ER_IRQn, I2C1_EV_IRQn},
-    {I2C2, GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 11), GPIO_OD_PU,
-     GPIO_AF4, I2C2_ER_IRQn, I2C2_EV_IRQn},
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B,  8),
+        .sda_pin        = GPIO_PIN(PORT_B,  9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = I2C_APBCLK,
+        .irqn           = I2C1_EV_IRQn
+    },
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C2EN,
+        .clk            = I2C_APBCLK,
+        .irqn           = I2C2_EV_IRQn
+    }
 };
+
 /** @} */
 
 /**


### PR DESCRIPTION
Code for nucleo-l152re won't compile due to obsolete i2c configuration in periph_conf.h.

The same issue probably persists in boards/limifrog-v1 and boards/nz32-sc151.